### PR TITLE
Mark igbinary and msgpack as optional extensions

### DIFF
--- a/docs/1.x/installation.md
+++ b/docs/1.x/installation.md
@@ -13,7 +13,6 @@ Before installing Relay, make sure the system meets the requirements:
 - PHP 7.4+
 - Redis Server 6.2.7+
 - The `json` and `session` PHP extensions
-- Optionally, the `igbinary` and/or `msgpack` PHP extensions to use the corresponding serializers (Relay detects them at runtime)
 
 ## macOS
 
@@ -236,7 +235,7 @@ which php
 
 ### 3. PHP extensions
 
-Next, make sure the PHP installation you picked in step 2 has the `json` and `session` extensions installed. The `igbinary` and `msgpack` extensions are optional — install them only if you want to use the corresponding serializers (Relay detects them at runtime).
+Next, make sure the PHP installation you picked in step 2 has the `json` and `session` extensions installed. The `igbinary` and `msgpack` extensions are optional, however the `igbinary` serializer is recommended.
 
 ```bash
 /usr/bin/php -m | grep -e json -e igbinary -e msgpack
@@ -245,7 +244,7 @@ Next, make sure the PHP installation you picked in step 2 has the `json` and `se
 # msgpack
 ```
 
-The `json` and `session` extensions are required; if either is missing, install it via `pecl` or the system's PHP package manager before continuing. The `igbinary` and `msgpack` extensions are optional and only needed for their serializers. _Do this for all PHP installations of step 2._
+If any of the required extensions are missing, be sure to install them via `pecl` or the system's PHP package manager before continuing. _Do this for all PHP installations of step 2._
 
 ### 4. Relay artifact
 
@@ -373,8 +372,7 @@ That's it, enjoy!
 
 ### TLDR
 
-First, ensure that the `json` and `session` PHP extensions are installed for all PHP installations (CLI, FPM, etc); the `igbinary` and `msgpack` extensions are optional and only needed for their serializers.
-Then make sure `zstd` and `lz4` are installed, as well as other required system libraries.
+First, ensure that the `json` and `session` PHP extensions are installed for all PHP installations (CLI, FPM, etc); the `igbinary` and `msgpack` extensions are optional. Then make sure `zstd` and `lz4` are installed, as well as other required system libraries.
 
 ```bash
 RELAY_VERSION="{{relay}}" # https://builds.r2.relay.so/meta/latest

--- a/docs/1.x/installation.md
+++ b/docs/1.x/installation.md
@@ -12,7 +12,8 @@ Before installing Relay, make sure the system meets the requirements:
 
 - PHP 7.4+
 - Redis Server 6.2.7+
-- The `json`, `session`, `igbinary` and `msgpack` PHP extensions
+- The `json` and `session` PHP extensions
+- Optionally, the `igbinary` and/or `msgpack` PHP extensions to use the corresponding serializers (Relay detects them at runtime)
 
 ## macOS
 
@@ -235,7 +236,7 @@ which php
 
 ### 3. PHP extensions
 
-Next, make sure the PHP installation you picked in step 2 has the `json`, `igbinary` and `msgpack` extensions installed.
+Next, make sure the PHP installation you picked in step 2 has the `json` and `session` extensions installed. The `igbinary` and `msgpack` extensions are optional — install them only if you want to use the corresponding serializers (Relay detects them at runtime).
 
 ```bash
 /usr/bin/php -m | grep -e json -e igbinary -e msgpack
@@ -244,7 +245,7 @@ Next, make sure the PHP installation you picked in step 2 has the `json`, `igbin
 # msgpack
 ```
 
-If any of the extensions are missing, be sure to install them via `pecl` or the system's PHP package manager before continuing. _Do this for all PHP installations of step 2._
+The `json` and `session` extensions are required; if either is missing, install it via `pecl` or the system's PHP package manager before continuing. The `igbinary` and `msgpack` extensions are optional and only needed for their serializers. _Do this for all PHP installations of step 2._
 
 ### 4. Relay artifact
 
@@ -372,7 +373,7 @@ That's it, enjoy!
 
 ### TLDR
 
-First, ensure that the `json`, `igbinary` and `msgpack` PHP extensions are installed for all PHP installations (CLI, FPM, etc).
+First, ensure that the `json` and `session` PHP extensions are installed for all PHP installations (CLI, FPM, etc); the `igbinary` and `msgpack` extensions are optional and only needed for their serializers.
 Then make sure `zstd` and `lz4` are installed, as well as other required system libraries.
 
 ```bash


### PR DESCRIPTION
`igbinary` and `msgpack` are now **optional** for Relay. As of the recent relay-core change, both serializers are compiled into Relay but **resolved at runtime** (bound via `dlsym` at module startup): if the extension is loaded the matching serializer is available, and if not, Relay still loads and works without it. `json` and `session` remain required.

Update `docs/1.x/installation.md` so igbinary/msgpack read as optional (Requirements list, manual install step 3, and the TLDR). `json` and `session` remain documented as required.

Part of a cross-repo sweep updating references that still treated these extensions as hard requirements.